### PR TITLE
Rewrite tests to TestHost

### DIFF
--- a/Tests/AppFactory.cs
+++ b/Tests/AppFactory.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Tests;
+
+public class AppFactory: WebApplicationFactory<WebApi.MinimalApi.Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Tests");
+    }
+}

--- a/Tests/AppFactory.cs
+++ b/Tests/AppFactory.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 
 namespace Tests;
 
-public class AppFactory: WebApplicationFactory<WebApi.MinimalApi.Program>
+internal class AppFactory: WebApplicationFactory<global::Program>
 {
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {

--- a/Tests/Task1_GetUserByIdTests.cs
+++ b/Tests/Task1_GetUserByIdTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using NUnit.Framework;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Tests
 {
@@ -9,13 +10,13 @@ namespace Tests
     public class Task1_GetUserByIdTests : UsersApiTestsBase
     {
         [Test]
-        public void Test1_Code200_WhenAllIsFine()
+        public async Task Test1_Code200_WhenAllIsFine()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Get;
             request.RequestUri = BuildUsersByIdUri("77777777-7777-7777-7777-777777777777");
             request.Headers.Add("Accept", "application/json");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -30,39 +31,39 @@ namespace Tests
         }
 
         [Test]
-        public void Test2_Code404_WhenUserIdIsUnknown()
+        public async Task Test2_Code404_WhenUserIdIsUnknown()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Get;
             request.RequestUri = BuildUsersByIdUri("77777777-6666-6666-6666-777777777777");
             request.Headers.Add("Accept", "application/json");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
             response.ShouldNotHaveHeader("Content-Type");
         }
 
         [Test]
-        public void Test3_Code404_WhenUserIdIsTrash()
+        public async Task Test3_Code404_WhenUserIdIsTrash()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Get;
             request.RequestUri = BuildUsersByIdUri("trash");
             request.Headers.Add("Accept", "application/json");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
             response.ShouldNotHaveHeader("Content-Type");
         }
 
         [Test]
-        public void Test4_Code200_WhenAcceptXml()
+        public async Task Test4_Code200_WhenAcceptXml()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Get;
             request.RequestUri = BuildUsersByIdUri("77777777-7777-7777-7777-777777777777");
             request.Headers.Add("Accept", "application/xml");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             response.ShouldHaveHeader("Content-Type", "application/xml; charset=utf-8");
@@ -72,13 +73,13 @@ namespace Tests
         }
 
         [Test]
-        public void Test5_Code406_WhenAcceptTextPlain()
+        public async Task Test5_Code406_WhenAcceptTextPlain()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Get;
             request.RequestUri = BuildUsersByIdUri("77777777-7777-7777-7777-777777777777");
             request.Headers.Add("Accept", "text/plain");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.NotAcceptable);
             response.ShouldNotHaveHeader("Content-Type");

--- a/Tests/Task2_CreateUserTests.cs
+++ b/Tests/Task2_CreateUserTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Tests
 {
@@ -11,7 +12,7 @@ namespace Tests
     public class Task2_CreateUserTests : UsersApiTestsBase
     {
         [Test]
-        public void Test1_Code201_WhenAllIsFine()
+        public async Task Test1_Code201_WhenAllIsFine()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Post;
@@ -23,7 +24,7 @@ namespace Tests
                 firstName = "Michael",
                 lastName = "Jackson"
             }.SerializeToJsonContent();
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.Created);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -44,21 +45,21 @@ namespace Tests
         }
 
         [Test]
-        public void Test2_Code400_WhenEmptyContent()
+        public async Task Test2_Code400_WhenEmptyContent()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Post;
             request.RequestUri = BuildUsersUri();
             request.Headers.Add("Accept", "*/*");
             request.AddEmptyContent("application/json; charset=utf-8");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
             response.ShouldNotHaveHeader("Content-Type");
         }
 
         [Test]
-        public void Test3_Code422_WhenEmptyLogin()
+        public async Task Test3_Code422_WhenEmptyLogin()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Post;
@@ -69,7 +70,7 @@ namespace Tests
                 firstName = "Michael",
                 lastName = "Jackson"
             }.SerializeToJsonContent();
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -79,7 +80,7 @@ namespace Tests
         }
 
         [Test]
-        public void Test4_Code422_WhenLoginWithUnallowedChars()
+        public async Task Test4_Code422_WhenLoginWithUnallowedChars()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Post;
@@ -91,7 +92,7 @@ namespace Tests
                 firstName = "Michael",
                 lastName = "Jackson"
             }.SerializeToJsonContent();
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -101,7 +102,7 @@ namespace Tests
         }
 
         [Test]
-        public void Test5_Code201_WithDefaultFirstNameAndLastName()
+        public async Task Test5_Code201_WithDefaultFirstNameAndLastName()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Post;
@@ -111,7 +112,7 @@ namespace Tests
             {
                 login = "anonymous"
             }.SerializeToJsonContent();
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.Created);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -132,7 +133,7 @@ namespace Tests
         }
 
         [Test]
-        public void Test6_Code201_WhenAcceptXml()
+        public async Task Test6_Code201_WhenAcceptXml()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Post;
@@ -144,7 +145,7 @@ namespace Tests
                 firstName = "Michael",
                 lastName = "Jackson"
             }.SerializeToJsonContent();
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.Created);
             response.ShouldHaveHeader("Content-Type", "application/xml; charset=utf-8");
@@ -154,7 +155,7 @@ namespace Tests
         }
 
         [Test]
-        public void Test7_Code406_WhenAcceptTextPlain()
+        public async Task Test7_Code406_WhenAcceptTextPlain()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Post;
@@ -166,7 +167,7 @@ namespace Tests
                 firstName = "Michael",
                 lastName = "Jackson"
             }.SerializeToJsonContent();
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.NotAcceptable);
             response.ShouldNotHaveHeader("Content-Type");

--- a/Tests/Task3_UpdateUserTests.cs
+++ b/Tests/Task3_UpdateUserTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Tests
 {
@@ -12,9 +13,9 @@ namespace Tests
     public class Task3_UpdateUserTests : UsersApiTestsBase
     {
         [Test]
-        public void Test1_Code204_WhenAllIsFine()
+        public async Task Test1_Code204_WhenAllIsFine()
         {
-            var createdUserId = CreateUser(new
+            var createdUserId = await CreateUser(new
             {
                 login = "anonymous"
             });
@@ -29,7 +30,7 @@ namespace Tests
                 firstName = "Vendetta",
                 lastName = "V"
             }.SerializeToJsonContent();
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.NoContent);
             response.ShouldNotHaveHeader("Content-Type");
@@ -45,7 +46,7 @@ namespace Tests
         }
 
         [Test]
-        public void Test2_Code201_WhenNoUser()
+        public async Task Test2_Code201_WhenNoUser()
         {
             var updatingUserId = Guid.NewGuid().ToString();
 
@@ -59,7 +60,7 @@ namespace Tests
                 firstName = "Michael",
                 lastName = "Jackson"
             }.SerializeToJsonContent();
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.Created);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -80,7 +81,7 @@ namespace Tests
         }
 
         [Test]
-        public void Test3_Code400_WhenUserIdIsTrash()
+        public async Task Test3_Code400_WhenUserIdIsTrash()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Put;
@@ -92,14 +93,14 @@ namespace Tests
                 firstName = "Vendetta",
                 lastName = "V"
             }.SerializeToJsonContent();
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
             response.ShouldNotHaveHeader("Content-Type");
         }
 
         [Test]
-        public void Test4_Code400_WhenEmptyContent()
+        public async Task Test4_Code400_WhenEmptyContent()
         {
             var updatingUserId = Guid.NewGuid().ToString();
 
@@ -108,16 +109,16 @@ namespace Tests
             request.RequestUri = BuildUsersByIdUri(updatingUserId);
             request.Headers.Add("Accept", "*/*");
             request.AddEmptyContent("application/json; charset=utf-8");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
             response.ShouldNotHaveHeader("Content-Type");
         }
 
         [Test]
-        public void Test5_Code422_WhenEmptyLogin()
+        public async Task Test5_Code422_WhenEmptyLogin()
         {
-            var createdUserId = CreateUser(new
+            var createdUserId = await CreateUser(new
             {
                 login = "anonymous"
             });
@@ -131,7 +132,7 @@ namespace Tests
                 firstName = "Vendetta",
                 lastName = "V"
             }.SerializeToJsonContent();
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -141,9 +142,9 @@ namespace Tests
         }
 
         [Test]
-        public void Test6_Code422_WhenLoginWithUnallowedChars()
+        public async Task Test6_Code422_WhenLoginWithUnallowedChars()
         {
-            var createdUserId = CreateUser(new
+            var createdUserId = await CreateUser(new
             {
                 login = "anonymous"
             });
@@ -158,7 +159,7 @@ namespace Tests
                 firstName = "Vendetta",
                 lastName = "V"
             }.SerializeToJsonContent();
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -168,9 +169,9 @@ namespace Tests
         }
 
         [Test]
-        public void Test7_Code422_WhenEmptyFirstName()
+        public async Task Test7_Code422_WhenEmptyFirstName()
         {
-            var createdUserId = CreateUser(new
+            var createdUserId = await CreateUser(new
             {
                 login = "anonymous"
             });
@@ -184,7 +185,7 @@ namespace Tests
                 login = "Anon",
                 lastName = "V"
             }.SerializeToJsonContent();
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -194,9 +195,9 @@ namespace Tests
         }
 
         [Test]
-        public void Test8_Code422_WhenEmptyLastName()
+        public async Task Test8_Code422_WhenEmptyLastName()
         {
-            var createdUserId = CreateUser(new
+            var createdUserId = await CreateUser(new
             {
                 login = "anonymous"
             });
@@ -210,7 +211,7 @@ namespace Tests
                 login = "Anon",
                 firstName = "Vendetta",
             }.SerializeToJsonContent();
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");

--- a/Tests/Task4_PartiallyUpdateUserTests.cs
+++ b/Tests/Task4_PartiallyUpdateUserTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Tests
 {
@@ -12,9 +13,9 @@ namespace Tests
     public class Task4_PartiallyUpdateUserTests : UsersApiTestsBase
     {
         [Test]
-        public void Test1_Code204_WhenAllIsFine()
+        public async Task Test1_Code204_WhenAllIsFine()
         {
-            var createdUserId = CreateUser(new
+            var createdUserId = await CreateUser(new
             {
                 login = "anonymous"
             });
@@ -40,7 +41,7 @@ namespace Tests
                     value = "V"
                 }
             }.SerializeToJsonContent("application/json-patch+json");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.NoContent);
             response.ShouldNotHaveHeader("Content-Type");
@@ -56,7 +57,7 @@ namespace Tests
         }
 
         [Test]
-        public void Test2_Code404_WhenNoUser()
+        public async Task Test2_Code404_WhenNoUser()
         {
             var updatingUserId = Guid.NewGuid().ToString();
 
@@ -81,14 +82,14 @@ namespace Tests
                     value = "V"
                 }
             }.SerializeToJsonContent("application/json-patch+json");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
             response.ShouldNotHaveHeader("Content-Type");
         }
 
         [Test]
-        public void Test3_Code404_WhenUserIdIsTrash()
+        public async Task Test3_Code404_WhenUserIdIsTrash()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Patch;
@@ -111,14 +112,14 @@ namespace Tests
                     value = "V"
                 }
             }.SerializeToJsonContent("application/json-patch+json");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
             response.ShouldNotHaveHeader("Content-Type");
         }
 
         [Test]
-        public void Test4_Code400_WhenEmptyContent()
+        public async Task Test4_Code400_WhenEmptyContent()
         {
             var updatingUserId = Guid.NewGuid().ToString();
 
@@ -127,16 +128,16 @@ namespace Tests
             request.RequestUri = BuildUsersByIdUri(updatingUserId);
             request.Headers.Add("Accept", "*/*");
             request.AddEmptyContent("application/json-patch+json");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
             response.ShouldNotHaveHeader("Content-Type");
         }
 
         [Test]
-        public void Test5_Code422_WhenEmptyLogin()
+        public async Task Test5_Code422_WhenEmptyLogin()
         {
-            var createdUserId = CreateUser(new
+            var createdUserId = await CreateUser(new
             {
                 login = "anonymous"
             });
@@ -152,7 +153,7 @@ namespace Tests
                     value = ""
                 }
             }.SerializeToJsonContent("application/json-patch+json");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -162,9 +163,9 @@ namespace Tests
         }
 
         [Test]
-        public void Test6_Code422_WhenLoginWithUnallowedChars()
+        public async Task Test6_Code422_WhenLoginWithUnallowedChars()
         {
-            var createdUserId = CreateUser(new
+            var createdUserId = await CreateUser(new
             {
                 login = "anonymous"
             });
@@ -180,7 +181,7 @@ namespace Tests
                     value = "!Anon!"
                 }
             }.SerializeToJsonContent("application/json-patch+json");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -190,9 +191,9 @@ namespace Tests
         }
 
         [Test]
-        public void Test7_Code422_WhenEmptyFirstName()
+        public async Task Test7_Code422_WhenEmptyFirstName()
         {
-            var createdUserId = CreateUser(new
+            var createdUserId = await CreateUser(new
             {
                 login = "anonymous"
             });
@@ -208,7 +209,7 @@ namespace Tests
                     value = ""
                 }
             }.SerializeToJsonContent("application/json-patch+json");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -218,9 +219,9 @@ namespace Tests
         }
 
         [Test]
-        public void Test8_Code422_WhenEmptyLastName()
+        public async Task Test8_Code422_WhenEmptyLastName()
         {
-            var createdUserId = CreateUser(new
+            var createdUserId = await CreateUser(new
             {
                 login = "anonymous"
             });
@@ -236,7 +237,7 @@ namespace Tests
                     value = ""
                 }
             }.SerializeToJsonContent("application/json-patch+json");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");

--- a/Tests/Task5_DeleteUserTests.cs
+++ b/Tests/Task5_DeleteUserTests.cs
@@ -1,20 +1,18 @@
 using FluentAssertions;
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
-using System;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Tests
 {
-
     [TestFixture]
     public class Task5_DeleteUserTests : UsersApiTestsBase
     {
         [Test]
-        public void Test1_Code204_WhenAllIsFine()
+        public async Task Test1_Code204_WhenAllIsFine()
         {
-            var createdUserId = CreateUser(new
+            var createdUserId = await CreateUser(new
             {
                 login = "condenado",
                 firstName = "a muerte",
@@ -25,42 +23,42 @@ namespace Tests
             request.Method = HttpMethod.Delete;
             request.RequestUri = BuildUsersByIdUri(createdUserId);
             request.Headers.Add("Accept", "*/*");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.NoContent);
             response.ShouldNotHaveHeader("Content-Type");
         }
 
         [Test]
-        public void Test2_Code404_WhenUserIsUnknown()
+        public async Task Test2_Code404_WhenUserIsUnknown()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Delete;
             request.RequestUri = BuildUsersByIdUri("77777777-6666-6666-6666-777777777777");
             request.Headers.Add("Accept", "*/*");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
             response.ShouldNotHaveHeader("Content-Type");
         }
 
         [Test]
-        public void Test3_Code404_WhenUserIdIsTrash()
+        public async Task Test3_Code404_WhenUserIdIsTrash()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Delete;
             request.RequestUri = BuildUsersByIdUri("trash");
             request.Headers.Add("Accept", "*/*");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
             response.ShouldNotHaveHeader("Content-Type");
         }
 
         [Test]
-        public void Test4_Code404_WhenAlreadyCreatedAndDeleted()
+        public async Task Test4_Code404_WhenAlreadyCreatedAndDeleted()
         {
-            var createdUserId = CreateUser(new
+            var createdUserId = await CreateUser(new
             {
                 login = "condenado",
                 firstName = "a muerte",
@@ -73,7 +71,7 @@ namespace Tests
             request.Method = HttpMethod.Delete;
             request.RequestUri = BuildUsersByIdUri(createdUserId);
             request.Headers.Add("Accept", "*/*");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
             response.ShouldNotHaveHeader("Content-Type");

--- a/Tests/Task6_HeadUserByIdTests.cs
+++ b/Tests/Task6_HeadUserByIdTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using NUnit.Framework;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Tests
 {
@@ -9,13 +10,13 @@ namespace Tests
     public class Task6_HeadUserByIdTests : UsersApiTestsBase
     {
         [Test]
-        public void Test1_Code200_WhenAllIsFine()
+        public async Task Test1_Code200_WhenAllIsFine()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Head;
             request.RequestUri = BuildUsersByIdUri("77777777-7777-7777-7777-777777777777");
             request.Headers.Add("Accept", "application/json");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -23,26 +24,26 @@ namespace Tests
         }
 
         [Test]
-        public void Test2_Code404_WhenUserIdIsUnknown()
+        public async Task Test2_Code404_WhenUserIdIsUnknown()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Head;
             request.RequestUri = BuildUsersByIdUri("77777777-6666-6666-6666-777777777777");
             request.Headers.Add("Accept", "application/json");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
             response.ShouldNotHaveHeader("Content-Type");
         }
 
         [Test]
-        public void Test3_Code404_WhenUserIdIsTrash()
+        public async Task Test3_Code404_WhenUserIdIsTrash()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Head;
             request.RequestUri = BuildUsersByIdUri("trash");
             request.Headers.Add("Accept", "application/json");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
             response.ShouldNotHaveHeader("Content-Type");

--- a/Tests/Task7_GetUsersTests.cs
+++ b/Tests/Task7_GetUsersTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Tests
 {
@@ -12,15 +13,15 @@ namespace Tests
     public class Task7_GetUsersTests : UsersApiTestsBase
     {
         [Test]
-        public void Test1_Code200_WhenFirstPage()
+        public async Task Test1_Code200_WhenFirstPage()
         {
-            CreateUniqueUsers(20);
+            await CreateUniqueUsers(20);
 
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Get;
             request.RequestUri = BuildUsersWithPagesUri(null, null);
             request.Headers.Add("Accept", "*/*");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -37,15 +38,15 @@ namespace Tests
         }
 
         [Test]
-        public void Test2_Code200_WhenSecondPage()
+        public async Task Test2_Code200_WhenSecondPage()
         {
-            CreateUniqueUsers(30);
+            await CreateUniqueUsers(30);
 
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Get;
             request.RequestUri = BuildUsersWithPagesUri(2, 10);
             request.Headers.Add("Accept", "*/*");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -62,13 +63,13 @@ namespace Tests
         }
 
         [Test]
-        public void Test3_Code200_WhenPageNumberMinIs1()
+        public async Task Test3_Code200_WhenPageNumberMinIs1()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Get;
             request.RequestUri = BuildUsersWithPagesUri(0, null);
             request.Headers.Add("Accept", "*/*");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -80,13 +81,13 @@ namespace Tests
         }
 
         [Test]
-        public void Test4_Code200_WhenPageSizeMinIs1()
+        public async Task Test4_Code200_WhenPageSizeMinIs1()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Get;
             request.RequestUri = BuildUsersWithPagesUri(null, 0);
             request.Headers.Add("Accept", "*/*");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -98,13 +99,13 @@ namespace Tests
         }
 
         [Test]
-        public void Test5_Code200_WhenPageSizeMaxIs20()
+        public async Task Test5_Code200_WhenPageSizeMaxIs20()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Get;
             request.RequestUri = BuildUsersWithPagesUri(null, 100);
             request.Headers.Add("Accept", "*/*");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -116,13 +117,13 @@ namespace Tests
         }
 
         [Test]
-        public void Test6_Code200_WhenPageSizeIs1()
+        public async Task Test6_Code200_WhenPageSizeIs1()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Get;
             request.RequestUri = BuildUsersWithPagesUri(null, 1);
             request.Headers.Add("Accept", "*/*");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -135,11 +136,11 @@ namespace Tests
             pagination.TotalPages.Should().Be(pagination.TotalCount);
         }
 
-        private void CreateUniqueUsers(int count)
+        private async Task CreateUniqueUsers(int count)
         {
             for (var i = 0; i < count; i++)
             {
-                CreateUser(new
+                await CreateUser(new
                 {
                     login = Guid.NewGuid().ToString().Replace("-", "")
                 });

--- a/Tests/Task8_GetUsersOptionsTests.cs
+++ b/Tests/Task8_GetUsersOptionsTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using NUnit.Framework;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Tests
 {
@@ -9,13 +10,13 @@ namespace Tests
     public class Task8_GetUsersOptionsTests : UsersApiTestsBase
     {
         [Test]
-        public void Test1_Code200_AllIsFine()
+        public async Task Test1_Code200_AllIsFine()
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Options;
             request.RequestUri = BuildUsersUri();
             request.Headers.Add("Accept", "*/*");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             response.ShouldNotHaveHeader("Content-Type");

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -12,11 +12,16 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="nunit" Version="3.14.0" />
+    <PackageReference Include="nunit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnitLite" Version="3.14.0" />
+    <PackageReference Include="NUnitLite" Version="4.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WebApi.MinimalApi\WebApi.MinimalApi.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Tests/UsersApiTestsBase.cs
+++ b/Tests/UsersApiTestsBase.cs
@@ -2,13 +2,24 @@ using FluentAssertions;
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using System.Web;
+using NUnit.Framework;
 
 namespace Tests
 {
     public abstract class UsersApiTestsBase
     {
-        protected readonly HttpClient httpClient = new HttpClient();
+        private AppFactory appFactory;
+
+        protected HttpClient HttpClient;
+
+        [SetUp]
+        public void CreateApp()
+        {
+            appFactory = new AppFactory();
+            HttpClient = appFactory.CreateClient();
+        }
 
         protected Uri BuildUsersByIdUri(string userId)
         {
@@ -38,44 +49,44 @@ namespace Tests
             return uriBuilder.Uri;
         }
 
-        protected void CheckUserCreated(string createdUserId, string createdUserUri, object expectedUser)
+        protected async Task CheckUserCreated(string createdUserId, string createdUserUri, object expectedUser)
         {
             // Проверка, что идентификатор созданного пользователя возвращается в теле ответа
-            CheckUser(createdUserId, expectedUser);
+            await CheckUser(createdUserId, expectedUser);
 
             // Проверка, что ссылка на созданного пользователя возвращается в заголовке Location
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Get;
             request.RequestUri = new Uri(createdUserUri);
             request.Headers.Add("Accept", "application/json");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
             response.ShouldHaveJsonContentEquivalentTo(expectedUser);
         }
 
-        protected void CheckUser(string userId, object expectedUser)
+        protected async Task CheckUser(string userId, object expectedUser)
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Get;
             request.RequestUri = BuildUsersByIdUri(userId);
             request.Headers.Add("Accept", "application/json");
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
             response.ShouldHaveJsonContentEquivalentTo(expectedUser);
         }
 
-        protected string CreateUser(object user)
+        protected async Task<string> CreateUser(object user)
         {
             var request = new HttpRequestMessage();
             request.Method = HttpMethod.Post;
             request.RequestUri = BuildUsersUri();
             request.Headers.Add("Accept", "*/*");
             request.Content = user.SerializeToJsonContent();
-            var response = httpClient.Send(request);
+            var response = await HttpClient.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.Created);
             response.ShouldHaveHeader("Content-Type", "application/json; charset=utf-8");
@@ -91,7 +102,7 @@ namespace Tests
             request.Method = HttpMethod.Delete;
             request.RequestUri = BuildUsersByIdUri(userId);
             request.Headers.Add("Accept", "*/*");
-            var response = httpClient.Send(request);
+            var response = HttpClient.Send(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.NoContent);
             response.ShouldNotHaveHeader("Content-Type");

--- a/Tests/UsersApiTestsBase.cs
+++ b/Tests/UsersApiTestsBase.cs
@@ -23,14 +23,14 @@ namespace Tests
 
         protected Uri BuildUsersByIdUri(string userId)
         {
-            var uriBuilder = new UriBuilder(Configuration.BaseUrl);
+            var uriBuilder = new UriBuilder();
             uriBuilder.Path = $"/api/users/{HttpUtility.UrlEncode(userId)}";
             return uriBuilder.Uri;
         }
 
         protected Uri BuildUsersUri()
         {
-            var uriBuilder = new UriBuilder(Configuration.BaseUrl);
+            var uriBuilder = new UriBuilder();
             uriBuilder.Path = $"/api/users";
             return uriBuilder.Uri;
         }
@@ -43,7 +43,7 @@ namespace Tests
             if (pageSize.HasValue)
                 query.Add("pageSize", pageSize.Value.ToString());
 
-            var uriBuilder = new UriBuilder(Configuration.BaseUrl);
+            var uriBuilder = new UriBuilder();
             uriBuilder.Path = $"/api/users";
             uriBuilder.Query = query.ToString();
             return uriBuilder.Uri;

--- a/WebApi.MinimalApi/Domain/IUserRepository.cs
+++ b/WebApi.MinimalApi/Domain/IUserRepository.cs
@@ -3,7 +3,7 @@ namespace WebApi.MinimalApi.Domain;
 public interface IUserRepository
 {
     UserEntity Insert(UserEntity user);
-    UserEntity FindById(Guid id);
+    UserEntity? FindById(Guid id);
     UserEntity GetOrCreateByLogin(string login);
     void Update(UserEntity user);
     void UpdateOrInsert(UserEntity user, out bool isInserted);

--- a/WebApi.MinimalApi/Domain/InMemoryUserRepository.cs
+++ b/WebApi.MinimalApi/Domain/InMemoryUserRepository.cs
@@ -28,7 +28,7 @@ public class InMemoryUserRepository : IUserRepository
         return Clone(id, entity);
     }
 
-    public UserEntity FindById(Guid id)
+    public UserEntity? FindById(Guid id)
     {
         return entities.TryGetValue(id, out var entity) ? Clone(id, entity) : null;
     }

--- a/WebApi.MinimalApi/Program.cs
+++ b/WebApi.MinimalApi/Program.cs
@@ -1,5 +1,3 @@
-using WebApi.MinimalApi.Domain;
-
 var builder = WebApplication.CreateBuilder(args);
 builder.WebHost.UseUrls("http://localhost:5000");
 builder.Services.AddControllers()

--- a/WebApi.MinimalApi/Program.cs
+++ b/WebApi.MinimalApi/Program.cs
@@ -11,13 +11,3 @@ var app = builder.Build();
 app.MapControllers();
 
 app.Run();
-
-namespace WebApi.MinimalApi
-{
-    public partial class Program
-    {
-        protected Program()
-        {
-        }
-    }
-}

--- a/WebApi.MinimalApi/Program.cs
+++ b/WebApi.MinimalApi/Program.cs
@@ -1,3 +1,5 @@
+using WebApi.MinimalApi.Domain;
+
 var builder = WebApplication.CreateBuilder(args);
 builder.WebHost.UseUrls("http://localhost:5000");
 builder.Services.AddControllers()
@@ -11,3 +13,13 @@ var app = builder.Build();
 app.MapControllers();
 
 app.Run();
+
+namespace WebApi.MinimalApi
+{
+    public partial class Program
+    {
+        protected Program()
+        {
+        }
+    }
+}

--- a/WebApi.MinimalApi/WebApi.MinimalApi.csproj
+++ b/WebApi.MinimalApi/WebApi.MinimalApi.csproj
@@ -6,6 +6,10 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>11</LangVersion>
     </PropertyGroup>
+    
+    <ItemGroup>
+      <InternalsVisibleTo Include="Tests"/>
+    </ItemGroup>
 
     <ItemGroup>
       <None Include="Samples\GameApi.postman_collection.json" />


### PR DESCRIPTION
Rewrite tests to TestHost in order to make application more debuggable and to not to use HTTPS in tests.
* Add configurable app factory.
* Use HttpClient from TestHost and its SendAsync instead of synchronous Send.
* Enhance types.